### PR TITLE
Replace threads with execution policies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,25 @@
 cmake_minimum_required(VERSION 3.22)
 project(raytracer CXX)
 
+if(NOT RT_EXECUTION_POLICY)
+    # seq
+    # par
+    # par_unseq
+    # unseq (c++20)
+    set(RT_EXECUTION_POLICY "par")
+endif()
+add_definitions(-DRT_EXECUTION_POLICY=${RT_EXECUTION_POLICY})
+
+if(NOT RT_ROW_METHOD)
+    # 0 - vector
+    # 1 - unique_ptr<unsigned[]>
+    # 2 - counting iterator
+    set(RT_ROW_METHOD 2)
+endif()
+add_definitions(-DRT_ROW_METHOD=${RT_ROW_METHOD})
+
 if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
+    find_package(TBB REQUIRED)
     add_compile_options(-Werror -Wall -Wextra -Wpedantic -Wshadow -Wconversion -Wsign-conversion -Wold-style-cast -ffast-math)
 elseif(MSVC)
     add_compile_options(/WX /W4 /permissive-)
@@ -19,7 +37,13 @@ add_executable(raytracer
     src/Raytracer.cpp
     src/Sphere.cpp
 )
+
 target_link_libraries(raytracer PRIVATE SFML::Graphics)
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
+    target_link_libraries(raytracer PRIVATE TBB::tbb)
+endif()
+
 target_compile_definitions(raytracer PRIVATE FONT_PATH="${CMAKE_SOURCE_DIR}/data")
 
 add_custom_target(format


### PR DESCRIPTION
This is an attempt at using execution policies to speed up (or at least simplify) rendering. It shaves off ~5% on my old Xeon(R) CPU E5-2430 0 @ 2.20GHz (12 hardware threads) which usually requires quite some time to spin up all cores.

It adds two CMake variables to configure the build:
*    `RT_EXECUTION_POLICY`
        - `seq` - All done in sequence, which can be used as a benchmark. Divide this time by the number of hardware threads and try to get close to that time using one of the other policies.
        - `par`
        - `par_unseq`
        - `unseq` (for C++20)

    (https://en.cppreference.com/w/cpp/algorithm/execution_policy_tag_t)

*    `RT_ROW_METHOD`
        - 0 - Use a `vector<unsigned>` for storing row numbers
        - 1 - Use a `unique_ptr<unsigned[]>` for storing row numbers
        - 2 - Use a `counting_iterator<unsigned>` for row numbers

The normal configuration ...

    cmake --preset dev

... defaults to

    cmake -DRT_EXECUTION_POLICY=par -DRT_ROW_METHOD=2 --preset dev